### PR TITLE
Add fleet-api workspace configuration file to the root of repo

### DIFF
--- a/fleet-api.code-workspace
+++ b/fleet-api.code-workspace
@@ -2,15 +2,15 @@
 	"folders": [
 		{
 			"name": "Root",
-			"path": "../../../../../"
+			"path": "."
 		},
 		{
 			"name": "Fleet API",
-			"path": "../../fleet-api"
+			"path": "./services/cloud/api/fleet-api/"
 		},
 		{
 			"name": "Fleet Contracts",
-			"path": "../../../../shared/contracts"
+			"path": "./services/shared/contracts/"
 		}
 	],
 	"settings": {


### PR DESCRIPTION
Moved the fleet-api code workspace to the root of the repo for easier navigation to quickly get to the workspace. This adheres to standards and best practices.